### PR TITLE
fix: parse subAttribute of complex attribute type

### DIFF
--- a/lib/scim/kit/v2/schema.rb
+++ b/lib/scim/kit/v2/schema.rb
@@ -45,13 +45,23 @@ module Scim
             ) do |x|
               x.meta = Meta.from(hash[:meta])
               hash[:attributes].each do |y|
-                x.attributes << AttributeType.from(y)
+                x.attributes << parse_attribute_type(y)
               end
             end
           end
 
           def parse(json)
             from(JSON.parse(json, symbolize_names: true))
+          end
+
+          private
+
+          def parse_attribute_type(hash)
+            attribute_type = AttributeType.from(hash)
+            hash[:subAttributes]&.each do |sub_attr_hash|
+              attribute_type.attributes << parse_attribute_type(sub_attr_hash)
+            end
+            attribute_type
           end
         end
       end

--- a/spec/scim/kit/v2/schema_spec.rb
+++ b/spec/scim/kit/v2/schema_spec.rb
@@ -126,28 +126,54 @@ RSpec.describe Scim::Kit::V2::Schema do
   describe '.parse' do
     let(:result) { described_class.parse(subject.to_json) }
 
-    before do
-      subject.add_attribute(name: :display_name) do |x|
-        x.multi_valued = true
-        x.required = true
-        x.case_exact = true
-        x.mutability = :read_only
-        x.returned = :never
-        x.uniqueness = :server
-        x.canonical_values = ['honerva']
-        x.reference_types = %w[User Group]
+    context "with reference attribute type" do
+      before do
+        subject.add_attribute(name: :display_name) do |x|
+          x.multi_valued = true
+          x.required = true
+          x.case_exact = true
+          x.mutability = :read_only
+          x.returned = :never
+          x.uniqueness = :server
+          x.canonical_values = ['honerva']
+          x.reference_types = %w[User Group]
+        end
       end
+
+      specify { expect(result.id).to eql(subject.id) }
+      specify { expect(result.name).to eql(subject.name) }
+      specify { expect(result.description).to eql(subject.description) }
+      specify { expect(result.meta.created).to eql(subject.meta.created) }
+      specify { expect(result.meta.last_modified).to eql(subject.meta.last_modified) }
+      specify { expect(result.meta.version).to eql(subject.meta.version) }
+      specify { expect(result.meta.location).to eql(subject.meta.location) }
+      specify { expect(result.meta.resource_type).to eql(subject.meta.resource_type) }
+      specify { expect(result.attributes.size).to eql(1) }
+      specify { expect(result.attributes.first.to_h).to eql(subject.attributes.first.to_h) }
+      specify { expect(result.to_json).to eql(subject.to_json) }
+      specify { expect(result.to_h).to eql(subject.to_h) }
     end
 
-    specify { expect(result.id).to eql(subject.id) }
-    specify { expect(result.name).to eql(subject.name) }
-    specify { expect(result.description).to eql(subject.description) }
-    specify { expect(result.meta.created).to eql(subject.meta.created) }
-    specify { expect(result.meta.last_modified).to eql(subject.meta.last_modified) }
-    specify { expect(result.meta.version).to eql(subject.meta.version) }
-    specify { expect(result.meta.location).to eql(subject.meta.location) }
-    specify { expect(result.meta.resource_type).to eql(subject.meta.resource_type) }
-    specify { expect(result.to_json).to eql(subject.to_json) }
-    specify { expect(result.to_h).to eql(subject.to_h) }
+    context "with complex attribute type" do
+      before do
+        subject.add_attribute(name: :name) do |x|
+          x.add_attribute(name: :family_name)
+          x.add_attribute(name: :given_name)
+        end
+      end
+
+      specify { expect(result.id).to eql(subject.id) }
+      specify { expect(result.name).to eql(subject.name) }
+      specify { expect(result.description).to eql(subject.description) }
+      specify { expect(result.meta.created).to eql(subject.meta.created) }
+      specify { expect(result.meta.last_modified).to eql(subject.meta.last_modified) }
+      specify { expect(result.meta.version).to eql(subject.meta.version) }
+      specify { expect(result.meta.location).to eql(subject.meta.location) }
+      specify { expect(result.meta.resource_type).to eql(subject.meta.resource_type) }
+      specify { expect(result.attributes.size).to eql(1) }
+      specify { expect(result.attributes.first.to_h).to eql(subject.attributes.first.to_h) }
+      specify { expect(result.to_json).to eql(subject.to_json) }
+      specify { expect(result.to_h).to eql(subject.to_h) }
+    end
   end
 end


### PR DESCRIPTION
use recursive parsing for Attribute type.

see #37

# Why is this needed?

fix #37 

## What does this do?

<!--
  Parse subAttribute of complex attribute type
-->

Fixes #37

<!--

### Screenshots

Before:

![Before][before]

After:

![After][after]

-->
## Type of change

<!-- Delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Verification Plan

<!-- How are we going to verify this change? -->

Simply by new test cases

[after]: https://user-images.githubusercontent.com/x/y.png
[before]: https://user-images.githubusercontent.com/x/y.png
