### PR TITLE
fix: errors in default error schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Version 0.5.2
+Version 0.5.3
 
 # Changelog
 All notable changes to this project will be documented in this file.
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.5.3] - 2022-05-13
+### Fixed
+
+- fix: change `status` attribute to type string in [error schema](https://www.rfc-editor.org/rfc/rfc7644.html#section-3.12)
+- fix: remove duplicate `invalidSyntax`
+- fix: add mising `invalidFilter`
 
 ## [0.5.2] - 2020-05-20
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    scim-kit (0.5.2)
+    scim-kit (0.5.3)
       activemodel (>= 6.1, < 8.0)
       net-hippie (~> 1.0)
       parslet (~> 2.0)

--- a/lib/scim/kit/v2/error.rb
+++ b/lib/scim/kit/v2/error.rb
@@ -6,8 +6,8 @@ module Scim
       # Represents a SCIM Error
       class Error < Resource
         SCIM_TYPES = %w[
+          invalidFilter
           invalidPath
-          invalidSyntax
           invalidSyntax
           invalidValue
           invalidVers
@@ -32,7 +32,7 @@ module Scim
               attribute.canonical_values = SCIM_TYPES
             end
             x.add_attribute(name: :detail)
-            x.add_attribute(name: :status, type: :integer)
+            x.add_attribute(name: :status, type: :string)
           end
         end
       end

--- a/lib/scim/kit/version.rb
+++ b/lib/scim/kit/version.rb
@@ -2,6 +2,6 @@
 
 module Scim
   module Kit
-    VERSION = '0.5.2'
+    VERSION = '0.5.3'
   end
 end

--- a/spec/scim/kit/v2/error_spec.rb
+++ b/spec/scim/kit/v2/error_spec.rb
@@ -12,5 +12,5 @@ RSpec.describe Scim::Kit::V2::Error do
   specify { expect(subject.to_h[:schemas]).to match_array([Scim::Kit::V2::Messages::ERROR]) }
   specify { expect(subject.to_h[:scimType]).to eql('invalidSyntax') }
   specify { expect(subject.to_h[:detail]).to eql('error') }
-  specify { expect(subject.to_h[:status]).to be(400) }
+  specify { expect(subject.to_h[:status]).to eql('400') }
 end

--- a/spec/scim/kit/v2/resource_spec.rb
+++ b/spec/scim/kit/v2/resource_spec.rb
@@ -590,6 +590,6 @@ RSpec.describe Scim::Kit::V2::Resource do
     specify { expect(subject.to_h[:schemas]).to match_array([Scim::Kit::V2::Messages::ERROR]) }
     specify { expect(subject.to_h[:scimType]).to eql('invalidSyntax') }
     specify { expect(subject.to_h[:detail]).to eql('error') }
-    specify { expect(subject.to_h[:status]).to be(400) }
+    specify { expect(subject.to_h[:status]).to eql('400') }
   end
 end


### PR DESCRIPTION
# Why is this needed?

To address errors in the default error schema that do not match the spec.

## What does this do?

It changes the default `error.status` field to a `string`, removes a duplicate
`error.scimType` and adds a missing `invalidFilter` `error.scimType`.

Fixes #46

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
