### PR TITLE
feat: add constants for standard schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-Version 0.6.0
+Version 0.7.0
 
 # Changelog
 All notable changes to this project will be documented in this file.
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.7.0] - 2022-09-28
+### Added
+- Add constant for 'urn:ietf:params:scim:api:messages:2.0:BulkRequest' [RFC-7644](https://www.rfc-editor.org/rfc/rfc7644.html#section-3.7)
+- Add constant for 'urn:ietf:params:scim:api:messages:2.0:BulkResponse' [RFC-7644](https://www.rfc-editor.org/rfc/rfc7644.html#section-3.7)
+- Add constant for 'urn:ietf:params:scim:api:messages:2.0:PatchOp' [RFC-7644](https://www.rfc-editor.org/rfc/rfc7644.html#section-3.5.2)
+- Add constant for 'urn:ietf:params:scim:schemas:core:2.0:Schema' [RFC-7643](https://www.rfc-editor.org/rfc/rfc7643.html#section-7)
+
+
 ## [0.6.0] - 2022-05-23
 ### Added
 - Add support for Ruby 3.1
@@ -73,7 +82,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - \_assign does not coerce values by default.
 - errors are merged together instead of overwritten during attribute validation.
 
-[Unreleased]: https://github.com/xlgmokha/scim-kit/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/xlgmokha/scim-kit/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/xlgmokha/scim-kit/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/xlgmokha/scim-kit/compare/v0.5.3...v0.6.0
 [0.5.3]: https://github.com/xlgmokha/scim-kit/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/xlgmokha/scim-kit/compare/v0.5.1...v0.5.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    scim-kit (0.6.0)
+    scim-kit (0.7.0)
       activemodel (>= 6.1, < 8.0)
       net-hippie (~> 1.0)
       parslet (~> 2.0)

--- a/lib/scim/kit/v2/messages.rb
+++ b/lib/scim/kit/v2/messages.rb
@@ -5,9 +5,12 @@ module Scim
     module V2
       module Messages
         CORE = 'urn:ietf:params:scim:api:messages:2.0'
-        LIST_RESPONSE = "#{CORE}:ListResponse"
-        SEARCH_REQUEST = "#{CORE}:SearchRequest"
+        BULK_REQUEST = "#{CORE}:BulkRequest"
+        BULK_RESPONSE = "#{CORE}:BulkResponse"
         ERROR = "#{CORE}:Error"
+        LIST_RESPONSE = "#{CORE}:ListResponse"
+        PATCH_OP = "#{CORE}:PatchOp"
+        SEARCH_REQUEST = "#{CORE}:SearchRequest"
       end
     end
   end

--- a/lib/scim/kit/v2/schemas.rb
+++ b/lib/scim/kit/v2/schemas.rb
@@ -11,6 +11,7 @@ module Scim
         ENTERPRISE_USER = "#{EXTENSION}:enterprise:2.0:User"
         GROUP = "#{CORE}:Group"
         RESOURCE_TYPE = "#{CORE}:ResourceType"
+        SCHEMA = "#{CORE}:Schema"
         SERVICE_PROVIDER_CONFIGURATION = "#{CORE}:ServiceProviderConfig"
         USER = "#{CORE}:User"
       end

--- a/lib/scim/kit/version.rb
+++ b/lib/scim/kit/version.rb
@@ -2,6 +2,6 @@
 
 module Scim
   module Kit
-    VERSION = '0.6.0'
+    VERSION = '0.7.0'
   end
 end


### PR DESCRIPTION
# Why is this needed?

## What does this do?

This change adds constants for standard schemas that are mentioned in
[RFC-7643](https://www.rfc-editor.org/rfc/rfc7643.html) and [RFC-7644](https://www.rfc-editor.org/rfc/rfc7644.html)

Fixes https://github.com/xlgmokha/scim-kit/issues/55

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
