### PR TITLE
Add support for "duplicate" attribute names

### DIFF
--- a/spec/scim/kit/v2/resource_spec.rb
+++ b/spec/scim/kit/v2/resource_spec.rb
@@ -184,6 +184,17 @@ RSpec.describe Scim::Kit::V2::Resource do
     specify { expect(subject.province).to eql('alberta') }
     specify { expect(subject.as_json[:country]).to eql('canada') }
     specify { expect(subject.as_json[extension_id][:province]).to eql('alberta') }
+
+    context "with an extension attribute with the same name as a core attribute" do
+      before do
+        extension.add_attribute(name: :country)
+        subject.country = 'usa'
+      end
+
+      specify { expect(subject.country).to eql('usa') }
+      specify { expect(subject.as_json[:country]).to eql('canada') }
+      specify { expect(subject.as_json[extension_id][:country]).to eql('usa') }
+    end
   end
 
   describe '#valid?' do

--- a/spec/scim/kit/v2/resource_spec.rb
+++ b/spec/scim/kit/v2/resource_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe Scim::Kit::V2::Resource do
     specify { expect(subject.as_json[:country]).to eql('canada') }
     specify { expect(subject.as_json[extension_id][:province]).to eql('alberta') }
 
-    context "with an extension attribute with the same name as a core attribute" do
+    context 'with an extension attribute with the same name as a core attribute' do
       before do
         extension.add_attribute(name: :country)
         subject.country = 'usa'


### PR DESCRIPTION
# Why is this needed?

A custom extension may define attributes that may already exist in core or other schema extensions. This should generally be acceptable as we have namespaces to disambiguate them. For example,

```json
{
  "name": {
    "givenName": "Kamal"
  },
  "urn:ietf:params:scim:schemas:extension:envoy:core:1.0:User": {
    "name": "Kamal"
  }
}
```

I should also note that the type can also be different. The core `name` attribute is a complex type, but the `urn:ietf:params:scim:schemas:extension:envoy:core:1.0:User.name` is a simple attribute.

Currently, `Scim::Kit` will generate a resource getter and setter that is not namespaced.

## What does this do?

This is not a fix, but only contains a failing spec to illustrate the issue.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Verification Plan

- [ ] Define a custom extension with an attribute name that already exist elsewhere
- [ ] Provide a payload with both attributes present

